### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,39 +1,41 @@
 {
-    "name": "Objects Interpolation on video",
-    "type": "app",
-    "instance_version": "6.15.60",
-    "categories": [
-        "neural network",
-        "videos",
-        "detection & tracking",
-        "segmentation & tracking",
-        "nn tools",
-        "data operations"
-    ],
-    "description": "Track polygons, rectangles and points using linear interpolation",
-    "poster": "https://user-images.githubusercontent.com/115161827/231768642-879cd495-903e-4ef2-a3de-b45a91a6f968.jpg",
-    "docker_image": "supervisely/data-operations:6.73.564",
-    "main_script": "src/main.py",
-    "modal_template": "src/modal.html",
-    "modal_template_state": {
-        "shapeComplexity": "greedily"
-    },
-    "task_location": "application_sessions",
-    "icon": "https://user-images.githubusercontent.com/115161827/231768582-ba91f0b5-af3e-400d-8dcd-d65ed8911cb7.png",
-    "icon_cover": true,
-    "isolate": true,
-    "headless": true,
-    "session_tags": [
-        "sly_video_tracking"
-    ],
-    "allowed_shapes": [
-        "polygon",
-        "point",
-        "rectangle"
-    ],
-    "community_agent": true,
-    "access_restriction": [{
-        "instance": "community_free",
-        "message": "The best object trackers are already deployed in the Supervisely Cloud and are available for auto-labeling to all platform users. The number of API calls and the ability to run this app on your own agent (GPU) are limited for Free accounts. To increase usage limits or run the app on your GPU, switch to the <a href=\"/billing\">Pro</a> plan or request the <a href=\"https://supervisely.com/contact-us/\" target=\"_blank\">Enterprise</a> Edition."
-    }]
+  "name": "Objects Interpolation on video",
+  "type": "app",
+  "instance_version": "6.15.60",
+  "categories": [
+    "neural network",
+    "videos",
+    "detection & tracking",
+    "segmentation & tracking",
+    "nn tools",
+    "data operations"
+  ],
+  "description": "Track polygons, rectangles and points using linear interpolation",
+  "poster": "https://user-images.githubusercontent.com/115161827/231768642-879cd495-903e-4ef2-a3de-b45a91a6f968.jpg",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "main_script": "src/main.py",
+  "modal_template": "src/modal.html",
+  "modal_template_state": {
+    "shapeComplexity": "greedily"
+  },
+  "task_location": "application_sessions",
+  "icon": "https://user-images.githubusercontent.com/115161827/231768582-ba91f0b5-af3e-400d-8dcd-d65ed8911cb7.png",
+  "icon_cover": true,
+  "isolate": true,
+  "headless": true,
+  "session_tags": [
+    "sly_video_tracking"
+  ],
+  "allowed_shapes": [
+    "polygon",
+    "point",
+    "rectangle"
+  ],
+  "community_agent": true,
+  "access_restriction": [
+    {
+      "instance": "community_free",
+      "message": "The best object trackers are already deployed in the Supervisely Cloud and are available for auto-labeling to all platform users. The number of API calls and the ability to run this app on your own agent (GPU) are limited for Free accounts. To increase usage limits or run the app on your GPU, switch to the <a href=\"/billing\">Pro</a> plan or request the <a href=\"https://supervisely.com/contact-us/\" target=\"_blank\">Enterprise</a> Edition."
+    }
+  ]
 }

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
     "name": "Objects Interpolation on video",
     "type": "app",
+    "instance_version": "6.15.60",
     "categories": [
         "neural network",
         "videos",

--- a/config.json
+++ b/config.json
@@ -11,7 +11,7 @@
     ],
     "description": "Track polygons, rectangles and points using linear interpolation",
     "poster": "https://user-images.githubusercontent.com/115161827/231768642-879cd495-903e-4ef2-a3de-b45a91a6f968.jpg",
-    "docker_image": "supervisely/data-operations:0.0.5",
+    "docker_image": "supervisely/data-operations:6.73.564",
     "main_script": "src/main.py",
     "modal_template": "src/modal.html",
     "modal_template_state": {

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.70
+supervisely==6.73.564

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 import functools
 
 import sly_globals as g
-import supervisely_lib as sly
+import supervisely as sly
 
 from tracker import InterpolationTracker
 from interpolation import (

--- a/src/sly_globals.py
+++ b/src/sly_globals.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 
 load_dotenv("debug.env")
 
-import supervisely_lib as sly
+import supervisely as sly
 
 
 logger = sly.logger

--- a/src/tracker/tracker.py
+++ b/src/tracker/tracker.py
@@ -9,7 +9,7 @@ from supervisely.geometry.geometry import Geometry
 
 from interpolation.base import BaseInterpolation
 
-import supervisely_lib as sly
+import supervisely as sly
 
 
 @dataclass


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
